### PR TITLE
Fix once helper unsubscribe

### DIFF
--- a/__tests__/eventEmitter.ts
+++ b/__tests__/eventEmitter.ts
@@ -204,6 +204,19 @@ describe("eventEmitter", () => {
 			expect(logUserLogin1).toHaveBeenCalledTimes(1);
 			expect(logUserLogin2).toHaveBeenCalledTimes(1);
 		});
+
+		it("should allow cancelling before the event is emitted", () => {
+			const logUserLogin = jest.fn();
+			const unsubscribe = onceSubscribe("userLogin", logUserLogin);
+
+			expect(typeof unsubscribe).toBe("function");
+
+			unsubscribe();
+
+			emit("userLogin", { userId: "user1", timestamp: new Date() });
+
+			expect(logUserLogin).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("awaited helper", () => {

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -533,7 +533,7 @@ export const createEventEmitter = <
 export type SubscribeOnce<Event extends EventDescription<string, UnsafeAny>> = <EventType extends keyof Event & string>(
 	eventName: EventType,
 	listener: EventListener<Event, EventType>
-) => void;
+) => UnsubscribeEvent;
 
 /**
  * Utility function to subscribe to an event only once. It automatically unsubscribes after the event is triggered.
@@ -549,6 +549,7 @@ export const once =
 			unsubscribe();
 			listener(eventName, data);
 		});
+		return unsubscribe;
 	};
 
 /**


### PR DESCRIPTION
## Summary
- return unsubscribe function from `once`
- update `SubscribeOnce` type
- test cancelling once subscriptions

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f41fed490832795af93b82d48d0f5