### PR TITLE
Fix listener array copy in emit

### DIFF
--- a/__tests__/eventEmitter.ts
+++ b/__tests__/eventEmitter.ts
@@ -146,6 +146,31 @@ describe("eventEmitter", () => {
 			expect(unsubscribeLogin()).toBe(false);
 		});
 
+		it("should invoke all listeners even if one unsubscribes another", () => {
+			const calls: string[] = [];
+			const first = jest.fn(() => {
+				unsubscribeSecond();
+				calls.push("first");
+			});
+			const second = jest.fn(() => {
+				calls.push("second");
+			});
+			const third = jest.fn(() => {
+				calls.push("third");
+			});
+
+			subscribe("userLogin", first);
+			const unsubscribeSecond = subscribe("userLogin", second);
+			subscribe("userLogin", third);
+
+			emit("userLogin", { userId: "user1", timestamp: new Date() });
+
+			expect(calls).toEqual(["first", "second", "third"]);
+			expect(first).toHaveBeenCalledTimes(1);
+			expect(second).toHaveBeenCalledTimes(1);
+			expect(third).toHaveBeenCalledTimes(1);
+		});
+
 		it("should not throw or cause issues when unsubscribeAll is called without any subscriptions", () => {
 			expect(() => {
 				unsubscribeAll(); // No subscriptions should exist at this point

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -478,7 +478,8 @@ export const createEventEmitter = <
 		if (!listenersMapEntry) {
 			return;
 		}
-		listenersMapEntry.listeners.forEach(({ listener, predicate }) => {
+		const listenersArray = [...listenersMapEntry.listeners.values()];
+		listenersArray.forEach(({ listener, predicate }) => {
 			if (predicate && !predicate(data)) {
 				return;
 			}


### PR DESCRIPTION
## Summary
- ensure emit iterates over a snapshot of listeners
- test unsubscribing during emit does not skip callbacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f48053af08327bb6e0a762a3d72d9